### PR TITLE
Pin MoltenVK version to v1.0.37

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ash-molten"
 description = "Statically linked MoltenVK for Vulkan on Mac using Ash"
-version = "0.1.0"
+version = "0.2.0+37"
 authors = ["Embark <opensource@embark-studios.com>", "Maik Klein <maik.klein@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -45,8 +45,19 @@ You can run the example with `cargo run`.
 
 ### Features
 
-`cargo build` will clone the newest master of [MoltenVK](https://github.com/KhronosGroup/MoltenVK) compile and statically link it with your application. 
+`cargo build` will clone a specific release of [MoltenVK](https://github.com/KhronosGroup/MoltenVK) compile and statically link it with your application. 
+
 If you want to compile [MoltenVK](https://github.com/KhronosGroup/MoltenVK) yourself, you can use the `external` feature. `cargo build --features external` requires `libMoltenVK` to be visible (`LD_LIBRARY_PATH`).
+
+### How to update
+
+To update the version of [MoltenVK](https://github.com/KhronosGroup/MoltenVK) uses, change the following:
+
+- In `build.rs`, change `let tag = "v1.0.37"` to the new [MoltenVK release](https://github.com/KhronosGroup/MoltenVK/releases) tag name
+- Update the crate version in `Cargo.toml`
+  - Bump the patch version
+  - Set the version metadata to the MoltenVK release. 
+  - E.g. `0.2.0+37` -> `0.2.1+38`.
 
 ## Contributing
 

--- a/build.rs
+++ b/build.rs
@@ -28,8 +28,11 @@ mod mac {
             },
         };
 
+        // MoltenVK git tagged release to use
+        let tag = "v1.0.37";
+
         let checkout_dir =
-            Path::new(&std::env::var("OUT_DIR").expect("Couldn't find OUT_DIR")).join("MoltenVK");
+            Path::new(&std::env::var("OUT_DIR").expect("Couldn't find OUT_DIR")).join(format!("MoltenVK-{}", tag));
 
         let exit = Arc::new(AtomicBool::new(false));
         let wants_exit = exit.clone();
@@ -59,6 +62,10 @@ mod mac {
         } else {
             Command::new("git")
                 .arg("clone")
+                .arg("--branch")
+                .arg(tag.to_owned())
+                .arg("--depth")
+                .arg("1")
                 .arg("https://github.com/KhronosGroup/MoltenVK.git")
                 .arg(&checkout_dir)
                 .spawn()

--- a/build.rs
+++ b/build.rs
@@ -31,8 +31,8 @@ mod mac {
         // MoltenVK git tagged release to use
         let tag = "v1.0.37";
 
-        let checkout_dir =
-            Path::new(&std::env::var("OUT_DIR").expect("Couldn't find OUT_DIR")).join(format!("MoltenVK-{}", tag));
+        let checkout_dir = Path::new(&std::env::var("OUT_DIR").expect("Couldn't find OUT_DIR"))
+            .join(format!("MoltenVK-{}", tag));
 
         let exit = Arc::new(AtomicBool::new(false));
         let wants_exit = exit.clone();


### PR DESCRIPTION
We've been getting build errors on latest MoltenVK commits (#4) and it is rather non-deterministic and unsafe to have all users build just from any latest commit. 

So let's just pin which MoltenVK release we use for ash-molten and publish crate release when there is a new MoltenVK release.

I've included the MoltenVK patch version name here in the crate version meta information, we can't bump this itself but we can do our own patch releases for the crate when updating the MoltenVK release also. This way we can continue to use semver and it is also clear for the users which MoltenVK release is being used.

I've switched to do a faster pull of only that tagged branch here also and without history as it is not needed to build.

Fix #4. 