### PR TITLE
Force the xcode lockfile into CARGO_BUILD_TARGET

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -26,9 +26,6 @@ mod mac {
                 Arc,
             },
         };
-        let derive_data_path =
-            PathBuf::from(std::env::var("OUT_DIR").expect("Couldn't find OUT_DIR"))
-                .join("moltenvk");
 
         // MoltenVK git tagged release to use
         let tag = "v1.0.38";

--- a/build.rs
+++ b/build.rs
@@ -15,8 +15,7 @@ mod mac {
                 }
                 None
             })
-            .find(|f| f == "EXTERNAL")
-            .is_some()
+            .any(|f| f == "EXTERNAL")
     }
 
     pub(crate) fn build_molten<P: AsRef<Path>>(target_dir: &P) -> &'static str {

--- a/build.rs
+++ b/build.rs
@@ -30,7 +30,6 @@ mod mac {
             PathBuf::from(std::env::var("OUT_DIR").expect("Couldn't find OUT_DIR"))
                 .join("moltenvk");
 
-
         // MoltenVK git tagged release to use
         let tag = "v1.0.38";
 

--- a/build.rs
+++ b/build.rs
@@ -101,6 +101,8 @@ mod mac {
             Err(e) => panic!("failed to determinte target os '{}'", e),
         };
         let status = Command::new("xcodebuild")
+            .env("XCODE_PROJ", "MoltenVKPackaging.xcodeproj")
+            .env("XCODE_SCHEME_BASE", "MoltenVK Package")
             .arg("-quiet")
             .arg("-project")
             .arg("\"MoltenVKPackaging.xcodeproj\"")

--- a/build.rs
+++ b/build.rs
@@ -108,10 +108,7 @@ mod mac {
             .arg("-project")
             .arg("MoltenVKPackaging.xcodeproj")
             .arg("-scheme")
-            .arg(format!(
-                "MoltenVK Package ({target} only)",
-                target = dir
-            ))
+            .arg(format!("MoltenVK Package ({target} only)", target = dir))
             .arg("-derivedDataPath")
             .arg(format!("{}", derive_data_path.display()))
             .arg("build")

--- a/build.rs
+++ b/build.rs
@@ -98,10 +98,10 @@ mod mac {
         let status = Command::new("xcodebuild")
             .arg("-quiet")
             .arg("-project")
-            .arg("$(XCODE_PROJ)")
+            .arg("MoltenVKPackaging.xcodeproj")
             .arg("-scheme")
             .arg(format!(
-                "$(XCODE_SCHEME_BASE) ({target} only)",
+                "MoltenVK Package ({target} only)",
                 target = dir
             ))
             .arg("-derivedDataPath")

--- a/build.rs
+++ b/build.rs
@@ -106,7 +106,7 @@ mod mac {
             .env("XCODE_SCHEME_BASE", "MoltenVK Package")
             .arg("-quiet")
             .arg("-project")
-            .arg("\"MoltenVKPackaging.xcodeproj\"")
+            .arg("MoltenVKPackaging.xcodeproj")
             .arg("-scheme")
             .arg(format!(
                 "\"MoltenVK Package ({target} only)\"",

--- a/build.rs
+++ b/build.rs
@@ -102,7 +102,7 @@ mod mac {
             .arg("-scheme")
             .arg(format!("MoltenVK Package ({target} only)", target = dir))
             .arg("-derivedDataPath")
-            .arg(std::env::var("CARGO_BUILD_TARGET").expect("Couldn't find TARGET_DIR"))
+            .arg(std::env::var("CARGO_TARGET_DIR").expect("Couldn't find TARGET_DIR"))
             .arg("build")
             .spawn()
             .expect("failed to spawn build")

--- a/build.rs
+++ b/build.rs
@@ -26,6 +26,12 @@ mod mac {
                 Arc,
             },
         };
+        let derive_data_path =
+            PathBuf::from(std::env::var("OUT_DIR").expect("Couldn't find OUT_DIR"))
+                .join("moltenvk");
+
+        // If there is a derive data path, just delete it. It is not needed and my contain locks.
+        let _ = std::fs::remove_dir_all(&derive_data_path);
 
         // MoltenVK git tagged release to use
         let tag = "v1.0.38";
@@ -94,7 +100,6 @@ mod mac {
             },
             Err(e) => panic!("failed to determinte target os '{}'", e),
         };
-
         let status = Command::new("xcodebuild")
             .arg("-quiet")
             .arg("-project")
@@ -102,7 +107,7 @@ mod mac {
             .arg("-scheme")
             .arg(format!("MoltenVK Package ({target} only)", target = dir))
             .arg("-derivedDataPath")
-            .arg(std::env::var("CARGO_TARGET_DIR").expect("Couldn't find TARGET_DIR"))
+            .arg(format!("{}", derive_data_path.display()))
             .arg("build")
             .spawn()
             .expect("failed to spawn build")

--- a/build.rs
+++ b/build.rs
@@ -30,14 +30,17 @@ mod mac {
             PathBuf::from(std::env::var("OUT_DIR").expect("Couldn't find OUT_DIR"))
                 .join("moltenvk");
 
-        // If there is a derive data path, just delete it. It is not needed and my contain locks.
-        let _ = std::fs::remove_dir_all(&derive_data_path);
 
         // MoltenVK git tagged release to use
         let tag = "v1.0.38";
 
         let checkout_dir = Path::new(&std::env::var("OUT_DIR").expect("Couldn't find OUT_DIR"))
             .join(format!("MoltenVK-{}", tag));
+        let derive_data_path = checkout_dir.join("moltenvk");
+
+        // If there is a derive data path, just delete it. It is not needed and may contain locks
+        // that not get deleted correctly
+        let _ = std::fs::remove_dir_all(&derive_data_path);
 
         let exit = Arc::new(AtomicBool::new(false));
         let wants_exit = exit.clone();

--- a/build.rs
+++ b/build.rs
@@ -105,7 +105,10 @@ mod mac {
             .arg("-project")
             .arg("\"MoltenVKPackaging.xcodeproj\"")
             .arg("-scheme")
-            .arg(format!("\"MoltenVK Package ({target} only)\"", target = dir))
+            .arg(format!(
+                "\"MoltenVK Package ({target} only)\"",
+                target = dir
+            ))
             .arg("-derivedDataPath")
             .arg(format!("\"{}\"", derive_data_path.display()))
             .arg("build")

--- a/build.rs
+++ b/build.rs
@@ -101,6 +101,7 @@ mod mac {
             Err(e) => panic!("failed to determinte target os '{}'", e),
         };
         let status = Command::new("xcodebuild")
+            .current_dir(&checkout_dir)
             .env("XCODE_PROJ", "MoltenVKPackaging.xcodeproj")
             .env("XCODE_SCHEME_BASE", "MoltenVK Package")
             .arg("-quiet")

--- a/build.rs
+++ b/build.rs
@@ -105,7 +105,7 @@ mod mac {
                 target = dir
             ))
             .arg("-derivedDataPath")
-            .arg(std::env::var("CARGO_TARGET_DIR").expect("Couldn't find TARGET_DIR"))
+            .arg(std::env::var("CARGO_BUILD_TARGET").expect("Couldn't find TARGET_DIR"))
             .arg("build")
             .spawn()
             .expect("failed to spawn build")

--- a/build.rs
+++ b/build.rs
@@ -103,18 +103,18 @@ mod mac {
         let status = Command::new("xcodebuild")
             .arg("-quiet")
             .arg("-project")
-            .arg("MoltenVKPackaging.xcodeproj")
+            .arg("\"MoltenVKPackaging.xcodeproj\"")
             .arg("-scheme")
-            .arg(format!("MoltenVK Package ({target} only)", target = dir))
+            .arg(format!("\"MoltenVK Package ({target} only)\"", target = dir))
             .arg("-derivedDataPath")
-            .arg(format!("{}", derive_data_path.display()))
+            .arg(format!("\"{}\"", derive_data_path.display()))
             .arg("build")
             .spawn()
             .expect("failed to spawn build")
             .wait()
             .expect("failed to build");
 
-        assert!(status.success(), "failed to fetchDependencies");
+        assert!(status.success(), "failed to build");
 
         let src = {
             let mut pb = PathBuf::new();

--- a/build.rs
+++ b/build.rs
@@ -96,13 +96,22 @@ mod mac {
             Err(e) => panic!("failed to determinte target os '{}'", e),
         };
 
-        let status = Command::new("make")
-            .current_dir(&checkout_dir)
-            .arg(target_name)
+        let status = Command::new("xcodebuild")
+            .arg("-quiet")
+            .arg("-project")
+            .arg("$(XCODE_PROJ)")
+            .arg("-scheme")
+            .arg(
+                format!("$(XCODE_SCHEME_BASE) ({target} only)"),
+                target = dir,
+            )
+            .arg("-derivedDataPath")
+            .arg(std::env::var("CARGO_TARGET_DIR").expect("Couldn't find TARGET_DIR"))
+            .arg("build")
             .spawn()
-            .expect("failed to spawn fetchDependencies")
+            .expect("failed to spawn build")
             .wait()
-            .expect("failed to fetchDependencies");
+            .expect("failed to build");
 
         assert!(status.success(), "failed to fetchDependencies");
 

--- a/build.rs
+++ b/build.rs
@@ -100,10 +100,7 @@ mod mac {
             .arg("-project")
             .arg("MoltenVKPackaging.xcodeproj")
             .arg("-scheme")
-            .arg(format!(
-                "MoltenVK Package ({target} only)",
-                target = dir
-            ))
+            .arg(format!("MoltenVK Package ({target} only)", target = dir))
             .arg("-derivedDataPath")
             .arg(std::env::var("CARGO_BUILD_TARGET").expect("Couldn't find TARGET_DIR"))
             .arg("build")

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ mod mac {
     pub(crate) fn is_external_enabled() -> bool {
         std::env::vars()
             .filter_map(|(flag, _)| {
-                const NAME: &'static str = "CARGO_FEATURE_";
+                const NAME: &str = "CARGO_FEATURE_";
                 if flag.starts_with(NAME) {
                     let feature = flag.split(NAME).nth(1).expect("").to_string();
                     println!("{:?}", feature);
@@ -101,10 +101,10 @@ mod mac {
             .arg("-project")
             .arg("$(XCODE_PROJ)")
             .arg("-scheme")
-            .arg(
-                format!("$(XCODE_SCHEME_BASE) ({target} only)"),
-                target = dir,
-            )
+            .arg(format!(
+                "$(XCODE_SCHEME_BASE) ({target} only)",
+                target = dir
+            ))
             .arg("-derivedDataPath")
             .arg(std::env::var("CARGO_TARGET_DIR").expect("Couldn't find TARGET_DIR"))
             .arg("build")

--- a/build.rs
+++ b/build.rs
@@ -109,11 +109,11 @@ mod mac {
             .arg("MoltenVKPackaging.xcodeproj")
             .arg("-scheme")
             .arg(format!(
-                "\"MoltenVK Package ({target} only)\"",
+                "MoltenVK Package ({target} only)",
                 target = dir
             ))
             .arg("-derivedDataPath")
-            .arg(format!("\"{}\"", derive_data_path.display()))
+            .arg(format!("{}", derive_data_path.display()))
             .arg("build")
             .spawn()
             .expect("failed to spawn build")


### PR DESCRIPTION
Potentially fixes #12

Instead of using make, we call xcodebuild directly and force the lock file into the target dir. 