### PR TITLE
Disable debug build for MoltenVK

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -96,9 +96,6 @@ mod mac {
 
         assert!(status.success(), "failed to fetchDependencies");
 
-        let mut target = target_name.to_owned();
-        target.push_str("-debug");
-
         let status = Command::new("make")
             .current_dir(&checkout_dir)
             .arg(target)

--- a/build.rs
+++ b/build.rs
@@ -98,7 +98,7 @@ mod mac {
 
         let status = Command::new("make")
             .current_dir(&checkout_dir)
-            .arg(target)
+            .arg(target_name)
             .spawn()
             .expect("failed to build MoltenVK")
             .wait()


### PR DESCRIPTION
I forgot to disable debug builds when upgrading to MoltenVK 1.1.0. This PR fixes that mistake