### PR TITLE
Faster CI by running pre-built test separately

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,20 +12,14 @@ jobs:
         with:
           toolchain: stable
           override: true
-
       # make sure all code has been formatted with rustfmt
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check --color always
-
       # run clippy to verify we have no warnings
       - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
@@ -37,8 +31,8 @@ jobs:
       - uses: actions/checkout@v1
       - uses: EmbarkStudios/cargo-deny-action@v1
 
-  test:
-    name: Test
+  test-source:
+    name: Test (source build)
     runs-on: macos-latest
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.1.app
@@ -51,6 +45,18 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
+
+  test:
+    name: Test (pre-built)
+    runs-on: macos-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.1.app
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: build

--- a/build.rs
+++ b/build.rs
@@ -116,6 +116,8 @@ mod mac {
 
         std::fs::create_dir_all(&target_dir).expect("Couldn't create directory");
 
+        let previous_path = env::current_dir().expect("Couldn't get current directory");
+
         std::env::set_current_dir(&target_dir).expect("Couldn't change current directory");
 
         let curl = Command::new("curl")
@@ -184,6 +186,8 @@ mod mac {
                 assert!(status.success());
             }
         }
+
+        std::env::set_current_dir(&previous_path).expect("Couldn't change current directory");
     }
 }
 
@@ -240,10 +244,6 @@ fn main() {
 
             pb
         };
-
-        eprintln!("{}", project_dir.display());
-        panic!();
-
         println!("cargo:rustc-link-search=native={}", project_dir.display());
     }
 

--- a/build.rs
+++ b/build.rs
@@ -116,7 +116,7 @@ mod mac {
 
         std::fs::create_dir_all(&target_dir).expect("Couldn't create directory");
 
-        let previous_path = env::current_dir().expect("Couldn't get current directory");
+        let previous_path = std::env::current_dir().expect("Couldn't get current directory");
 
         std::env::set_current_dir(&target_dir).expect("Couldn't change current directory");
 

--- a/build.rs
+++ b/build.rs
@@ -241,6 +241,9 @@ fn main() {
             pb
         };
 
+        eprintln!("{}", project_dir.display());
+        panic!();
+
         println!("cargo:rustc-link-search=native={}", project_dir.display());
     }
 


### PR DESCRIPTION
Moves the pre-built feature verification to a separate step that can be verified in isolation much faster. And uses the same for linting also as we don't really care about building MoltenVK source for that.

Although looks the `pre-built` feature doesn't work correctly as it is failing now, was probably just working before on CI because it just before in the same step built it without pre-built which would have resulted in a library binary in the target laying around