### PR TITLE
Initial aarch64 source build support and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.1.app
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -28,16 +28,16 @@ jobs:
   cargo-deny:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
 
-  test-source:
-    name: Test (source build)
+  test-mac-x64-source:
+    name: Test Mac x64 (source build)
     runs-on: macos-latest
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.1.app
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -46,13 +46,13 @@ jobs:
         with:
           command: build
 
-  test:
-    name: Test (pre-built)
+  test-mac-x64-prebuilt:
+    name: Test Mac x64 (pre-built)
     runs-on: macos-latest
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.1.app
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -61,3 +61,21 @@ jobs:
         with:
           command: build
           args: --verbose --features pre-built
+
+
+  test-mac-aarch64-source:
+    name: Test Mac aarch64 (source build)
+    runs-on: macos-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.1.app
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: aarch64-apple-darwin
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target aarch64-apple-darwin

--- a/build.rs
+++ b/build.rs
@@ -215,7 +215,7 @@ fn main() {
         )
         .join(&target_dir)
         .join("Package/Latest/MoltenVK/MoltenVK.xcframework");
-        
+
         let static_lib_dir = framework_path.join(format!(
             "{}-{}",
             std::env::var("CARGO_CFG_TARGET_OS").unwrap(),
@@ -224,25 +224,27 @@ fn main() {
 
         let static_lib_path = static_lib_dir.join("libMoltenVK.a");
         if !static_lib_path.exists() {
-  /*
-            panic!(
-                "Couldn't find static library: {}",
-                static_lib_path.display()
-            );
-*/
+            /*
+                        panic!(
+                            "Couldn't find static library: {}",
+                            static_lib_path.display()
+                        );
+            */
             let fat_static_lib_dir = format!(
                 "{}-{}",
                 std::env::var("CARGO_CFG_TARGET_OS").unwrap(),
                 "arm64_x86_64"
             );
-            let fat_static_lib_path = framework_path.join(fat_static_lib_dir).join("libMoltenVK.a");
+            let fat_static_lib_path = framework_path
+                .join(fat_static_lib_dir)
+                .join("libMoltenVK.a");
             if !fat_static_lib_path.exists() {
                 panic!(
                     "Couldn't find fat static library: {}",
                     fat_static_lib_path.display()
                 );
             }
-    
+
             let thin_static_lib_dir = target_dir.join("thin-arm64");
             std::fs::create_dir_all(&thin_static_lib_dir).unwrap();
             let thin_static_lib_path = thin_static_lib_dir.join("libMoltenVK.a");
@@ -264,12 +266,17 @@ fn main() {
                     thin_static_lib_path.display()
                 );
             }
-    
-            println!("cargo:rustc-link-search=native={}", thin_static_lib_dir.display());
-        } else {
-            println!("cargo:rustc-link-search=native={}", static_lib_dir.display());
-        }
 
+            println!(
+                "cargo:rustc-link-search=native={}",
+                thin_static_lib_dir.display()
+            );
+        } else {
+            println!(
+                "cargo:rustc-link-search=native={}",
+                static_lib_dir.display()
+            );
+        }
     } else if pre_built_enabled {
         let target_dir = Path::new(&std::env::var("OUT_DIR").unwrap())
             .join(format!("Prebuilt-MoltenVK-{}", crate::mac::VERSION));


### PR DESCRIPTION
Makes it possible to build from source for the new `aarch64-apple-darwin` target with Rust 1.50 (currently using nightly). Adds CI step for it as well through cross-compilation on x64 to aarch64.

This does not add pre-built libraries for the the target, that is tracked in #36.

Need to clean up this code some more before merging it, on aarch64 MoltenVK is built as a multi-target fat library with both x86_64 and aarch64 architectures in it, but seems like Rust can't link that so I use `lipo` to extract out the arm static library from the fat library and then we use that. A bit manual but seems to work!