### PR TITLE
Refactor MoltenEntry onto ash::EntryCustom

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,8 @@
 // crate-specific exceptions:
 #![allow(unsafe_code)]
 
-use ash::{version::EntryV1_0, vk, Instance, InstanceError, RawPtr};
+use ash::{vk, EntryCustom, LoadingError};
+use std::ops::{Deref, DerefMut};
 
 extern "system" {
     fn vkGetInstanceProcAddr(
@@ -62,62 +63,41 @@ extern "system" {
     ) -> vk::PFN_vkVoidFunction;
 }
 
-extern "system" fn get_instance_proc_addr(
-    instance: vk::Instance,
-    p_name: *const std::os::raw::c_char,
-) -> vk::PFN_vkVoidFunction {
-    unsafe { vkGetInstanceProcAddr(instance, p_name) }
-}
+/// ZST used as a tag for [ash::EntryCustom]
+pub struct MoltenLibStatic;
 
 /// The entry point for the statically linked molten library
-pub struct MoltenEntry {
-    static_fn: vk::StaticFn,
-    entry_fn_1_0: vk::EntryFnV1_0,
-}
+pub struct MoltenEntry(EntryCustom<MoltenLibStatic>);
 
 impl MoltenEntry {
-    /// Fetches the function pointer to `get_instance_proc_addr` which is statically linked. This
+    /// Fetches the function pointer to `vkGetInstanceProcAddr` which is statically linked. This
     /// function can not fail.
-    pub fn load() -> Result<MoltenEntry, ash::LoadingError> {
-        let static_fn = vk::StaticFn {
-            get_instance_proc_addr,
-        };
-
-        let entry_fn_1_0 = vk::EntryFnV1_0::load(|name| unsafe {
-            std::mem::transmute(
-                static_fn.get_instance_proc_addr(vk::Instance::null(), name.as_ptr()),
-            )
-        });
-
-        Ok(MoltenEntry {
-            static_fn,
-            entry_fn_1_0,
-        })
+    pub fn load() -> Result<MoltenEntry, LoadingError> {
+        // Defer the rest of the loading to EntryCustom
+        Ok(MoltenEntry(EntryCustom::new_custom(
+            MoltenLibStatic,
+            Self::static_loader,
+        )))
+    }
+    #[doc(hidden)]
+    fn static_loader(
+        _lib: &mut MoltenLibStatic,
+        _name: &std::ffi::CStr,
+    ) -> *const core::ffi::c_void {
+        // Cast function pointer to *const c_void; EntryCustom::new_custom calls StaticFn::load
+        // which performs the reverse operation using std::mem::transmute.
+        vkGetInstanceProcAddr as *const core::ffi::c_void
     }
 }
-impl EntryV1_0 for MoltenEntry {
-    type Instance = Instance;
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateInstance.html>"]
-    unsafe fn create_instance(
-        &self,
-        create_info: &vk::InstanceCreateInfo,
-        allocation_callbacks: Option<&vk::AllocationCallbacks>,
-    ) -> Result<Self::Instance, InstanceError> {
-        let mut instance: vk::Instance = vk::Instance::null();
-        let err_code = self.fp_v1_0().create_instance(
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut instance,
-        );
-        if err_code != vk::Result::SUCCESS {
-            return Err(InstanceError::VkError(err_code));
-        }
-        Ok(Instance::load(&self.static_fn, instance))
+impl Deref for MoltenEntry {
+    type Target = EntryCustom<MoltenLibStatic>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
-    fn fp_v1_0(&self) -> &vk::EntryFnV1_0 {
-        &self.entry_fn_1_0
-    }
-    fn static_fn(&self) -> &vk::StaticFn {
-        &self.static_fn
+}
+impl DerefMut for MoltenEntry {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }


### PR DESCRIPTION
This removes a lot of the boilerplate implementation code for `MoltenEntry` by deferring most of it to a wrapped `ash::EntryCustom`.

It also adds functionality like `try_enumerate_instance_version`, for "free".

I'd originally planned to just add an `impl EntryV1_1` to the existing `MoltenEntry`, but realised that would consist entirely of just copying code from `impl<L> EntryV1_1 for EntryCustom<L>`.

Thoughts, comments, and criticisms are welcome :)