### PR TITLE
MoltenVK 1.1.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,9 @@ name: CI
 jobs:
   lint:
     name: Lint
-    runs-on: macos-latest
+    runs-on: macos-11
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.1.app
+      DEVELOPER_DIR: /Applications/Xcode_12.5.app
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -33,9 +33,9 @@ jobs:
 
   test-source:
     name: Test (source build)
-    runs-on: macos-latest
+    runs-on: macos-11
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.1.app
+      DEVELOPER_DIR: /Applications/Xcode_12.5.app
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -47,9 +47,9 @@ jobs:
 
   test:
     name: Test (pre-built)
-    runs-on: macos-latest
+    runs-on: macos-11
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.1.app
+      DEVELOPER_DIR: /Applications/Xcode_12.5.app
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ash-molten"
 description = "Statically linked MoltenVK for Vulkan on Mac using Ash"
-version = "0.9.0+1.1.2-f28ab1c"
+version = "0.10.0+1.1.3"
 authors = ["Embark <opensource@embark-studios.com>", "Maik Klein <maik.klein@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/build/build.rs
+++ b/build/build.rs
@@ -62,7 +62,7 @@ mod mac {
 
     // MoltenVK git tagged release to use
     pub static MOLTEN_VK_VERSION: &str = "1.1.3";
-    pub static MOLTEN_VK_PATCH: Option<&str> = Some("f28ab1c");
+    pub static MOLTEN_VK_PATCH: Option<&str> = None;
 
     // Return the artifact tag in the form of "x.x.x" or if there is a patch specified "x.x.x#yyyyyyy"
     pub(crate) fn get_artifact_tag() -> String {

--- a/build/build.rs
+++ b/build/build.rs
@@ -61,7 +61,7 @@ mod mac {
     use std::path::Path;
 
     // MoltenVK git tagged release to use
-    pub static MOLTEN_VK_VERSION: &str = "1.1.2";
+    pub static MOLTEN_VK_VERSION: &str = "1.1.3";
     pub static MOLTEN_VK_PATCH: Option<&str> = Some("f28ab1c");
 
     // Return the artifact tag in the form of "x.x.x" or if there is a patch specified "x.x.x#yyyyyyy"


### PR DESCRIPTION
Bumped ash-moltens version number to `0.10.0` and updated MoltenVK to 1.1.3

CI is still running into https://github.com/EmbarkStudios/ash-molten/issues/46. Tested locally on M1✔