### PR TITLE
Update ash to 0.35

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/ash-molten"
 build = "build/build.rs"
 
 [dependencies]
-ash = { version = "0.33", default-features = false }
+ash = { version = "0.34", default-features = false }
 
 [build-dependencies]
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/ash-molten"
 build = "build/build.rs"
 
 [dependencies]
-ash = { version = "0.34", default-features = false }
+ash = { version = "0.35", default-features = false }
 
 [build-dependencies]
 anyhow = "1.0"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -74,7 +74,7 @@ use ash::vk;
 use std::ffi::CString;
 fn main() {
     unsafe {
-        let entry = ash_molten::MoltenEntry::load();
+        let entry = ash_molten::load();
         let app_name = CString::new("Hello Static Molten").unwrap();
 
         let appinfo = vk::ApplicationInfo::builder()


### PR DESCRIPTION
Again, not super sure what I'm doing here, but I thiink this is the right thing to do.

Checked updating this in rust-gpu (which is where I ran into ash-molten not supporting ash 0.34), and it seems to work.