### PR TITLE
Update MoltenVK to 1.1.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ash-molten"
 description = "Statically linked MoltenVK for Vulkan on Mac using Ash"
-version = "0.12.0+1.1.5"
+version = "0.12.1+1.1.10"
 authors = ["Embark <opensource@embark-studios.com>", "Maik Klein <maik.klein@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/build/build.rs
+++ b/build/build.rs
@@ -222,7 +222,7 @@ mod mac {
 
         let download_url = format!(
             "https://github.com/EmbarkStudios/ash-molten/releases/download/MoltenVK-{}/MoltenVK.xcframework.zip",
-            get_artifact_tag().replace("#", "%23")
+            get_artifact_tag().replace('#', "%23")
         );
         let download_path = target_dir.as_ref().join("MoltenVK.xcframework.zip");
 

--- a/build/build.rs
+++ b/build/build.rs
@@ -78,7 +78,7 @@ mod mac {
     use std::path::Path;
 
     // MoltenVK git tagged release to use
-    pub static MOLTEN_VK_VERSION: &str = "1.1.5";
+    pub static MOLTEN_VK_VERSION: &str = "1.1.10";
     pub static MOLTEN_VK_PATCH: Option<&str> = None;
 
     // Return the artifact tag in the form of "x.x.x" or if there is a patch specified "x.x.x#yyyyyyy"


### PR DESCRIPTION
No ash upgrade in this one, so only need a minor version bump.

Once this is in I can tag and upload the new prebuilt MoltenVK.