### PR TITLE
Update MoltenVK to 1.1.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ash-molten"
 description = "Statically linked MoltenVK for Vulkan on Mac using Ash"
-version = "0.12.1+1.1.10"
+version = "0.13.0+1.1.10"
 authors = ["Embark <opensource@embark-studios.com>", "Maik Klein <maik.klein@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ash-molten"
 description = "Statically linked MoltenVK for Vulkan on Mac using Ash"
-version = "0.12.0+1.1.5"
+version = "0.12.1+1.1.10"
 authors = ["Embark <opensource@embark-studios.com>", "Maik Klein <maik.klein@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<!-- markdownlint-disable-file MD004 -->
+<!-- markdownlint-disable-file MD034 -->
+
 # 🌋 ash-molten
 
 [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](https://embark.dev)
@@ -41,6 +44,7 @@ let instance = entry.create_instance(&create_info, None).expect("Instance");
 let devices = instance.enumerate_physical_devices();
 println!("{:?}", devices);
 ```
+
 You can run the example with `cargo run`.
 
 ## How does it work?
@@ -63,11 +67,12 @@ To update the version of [MoltenVK](https://github.com/KhronosGroup/MoltenVK) us
 - Update the crate version in `Cargo.toml`
   - Bump the patch version
   - Set the version metadata to the MoltenVK release.
-  - E.g. `0.2.0+37` -> `0.2.1+38`.
+  - E.g. `0.2.0+1.1.9` -> `0.2.1+1.1.10`.
+- Before you can submit the PR, you must also update the prebuilt version. See the next section.
 
 ### Updating pre-built version
 
-To update the prebuilt version uses, change the following:
+To update the prebuilt version of MoltenVK that ash-molten uses, change the following:
 
 - Follow the steps mentioned above.
 - Download the MoltenVK XCFramework from, for example, the Vulkan SDK for Mac or build [MoltenVK](https://github.com/KhronosGroup/MoltenVK/) yourself.

--- a/build/build.rs
+++ b/build/build.rs
@@ -222,7 +222,7 @@ mod mac {
 
         let download_url = format!(
             "https://github.com/EmbarkStudios/ash-molten/releases/download/MoltenVK-{}/MoltenVK.xcframework.zip",
-            get_artifact_tag().replace("#", "%23")
+            get_artifact_tag().replace('#', "%23")
         );
         let download_path = target_dir.as_ref().join("MoltenVK.xcframework.zip");
 

--- a/build/build.rs
+++ b/build/build.rs
@@ -78,7 +78,7 @@ mod mac {
     use std::path::Path;
 
     // MoltenVK git tagged release to use
-    pub static MOLTEN_VK_VERSION: &str = "1.1.5";
+    pub static MOLTEN_VK_VERSION: &str = "1.1.10";
     pub static MOLTEN_VK_PATCH: Option<&str> = None;
 
     // Return the artifact tag in the form of "x.x.x" or if there is a patch specified "x.x.x#yyyyyyy"


### PR DESCRIPTION
Replaces #67 .

No ash upgrade in this one, so only need a minor version bump?

Although the MoltenVK upgrade is large (from 1.1.5 to 1.1.10) so I decided to make this a "major" bump anyway, just to be safe.