### PR TITLE
Add some build.rs options to aid MoltenVK bisection

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -236,7 +236,7 @@ mod mac {
 
         let download_url = format!(
             "https://github.com/EmbarkStudios/ash-molten/releases/download/MoltenVK-{}/MoltenVK.xcframework.zip",
-            get_artifact_tag().replace("#", "%23")
+            get_artifact_tag().replace('#', "%23")
         );
         let download_path = target_dir.as_ref().join("MoltenVK.xcframework.zip");
 
@@ -338,10 +338,8 @@ fn main() {
             pb
         };
 
-        let xcframework = xcframework::XcFramework::parse(&project_dir).expect(&format!(
-            "Failed to parse XCFramework from {:?}",
-            project_dir
-        ));
+        let xcframework = xcframework::XcFramework::parse(&project_dir)
+            .unwrap_or_else(|_| panic!("Failed to parse XCFramework from {:?}", project_dir));
         let native_libs = xcframework
             .AvailableLibraries
             .into_iter()

--- a/build/build.rs
+++ b/build/build.rs
@@ -86,8 +86,8 @@ mod mac {
     // MOLTEN_VK_LOCAL lets you build directly from a local MoltenVK checkout, in which you can run
     // a `git bisect`, for example.
     // TODO: Make it possible to set these by environment variable?
-    pub static MOLTEN_VK_LOCAL_BIN: Option<&str> = None;  // for example, Some("/Users/my_user_name/VulkanSDK/1.3.211.0/MoltenVK")
-    pub static MOLTEN_VK_LOCAL: Option<&str> = None;  // for example, Some("/Users/my_user_name/dev/MoltenVK");
+    pub static MOLTEN_VK_LOCAL_BIN: Option<&str> = None; // for example, Some("/Users/my_user_name/VulkanSDK/1.3.211.0/MoltenVK")
+    pub static MOLTEN_VK_LOCAL: Option<&str> = None; // for example, Some("/Users/my_user_name/dev/MoltenVK");
 
     // Return the artifact tag in the form of "x.x.x" or if there is a patch specified "x.x.x#yyyyyyy"
     pub(crate) fn get_artifact_tag() -> String {


### PR DESCRIPTION
This adds two hardcoded options to build.rs to let you easily use a local prebuilt MoltenVK library, or to build from a local directory. The latter is especially useful when trying to bisect down regressions in MoltenVK itself.

Also improves the logging somewhat.