### PR TITLE
Widen `ash` support up to `0.37`, and bump version to `0.13.1`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ash-molten"
 description = "Statically linked MoltenVK for Vulkan on Mac using Ash"
-version = "0.13.0+1.1.10"
+version = "0.13.1+1.1.10"
 authors = ["Embark <opensource@embark-studios.com>", "Maik Klein <maik.klein@embark-studios.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -13,8 +13,15 @@ homepage = "https://github.com/EmbarkStudios/ash-molten"
 documentation = "https://docs.rs/ash-molten"
 build = "build/build.rs"
 
-[dependencies]
-ash = { version = "0.35", default-features = false }
+[dependencies.ash]
+# When breaking changes aren't needed (which is likely because of how little
+# of `ash` is being interfaced with), it's beneficial to keep widening the
+# version range range here, and only bumping `ash-molten`'s *patch* number.
+#
+# NB: you must check that `ash-molten` compiles with every `ash` version
+# in this range, not just the start and the end, to be sure it's compatible.
+version = ">=0.35, <=0.37"
+default-features = false
 
 [build-dependencies]
 anyhow = "1.0"

--- a/deny.toml
+++ b/deny.toml
@@ -14,4 +14,5 @@ allow = [
     "ISC",
     "MIT",
     "MPL-2.0",
+    "Unicode-DFS-2016",
 ]


### PR DESCRIPTION
As explained in the comment left in `Cargo.toml`, we can support multiple (otherwise "breaking") versions of `ash`, because very little of `ash`'s API surface is being interfaced with.

I've tested the code with `ash` at `0.35`, `0.36`, `0.37` and they all pass `cargo check`, but I don't have a macOS system to test that it actually runs - still, the API is so simple I can't imagine it breaking in a subtle way.

Since this is backwards-compatible, I've only bumped the patch number in `ash-molten`'s version, and we can continue to do so in the future to support more `ash` versions.

Something I'm not sure about is: should CI try all supported `ash` versions to avoid regressing?

---

As for why I need this: bumping `wgpu` in Rust-GPU, for `example-runner-wgpu`, requires `ash 0.37`, and `ash-molten` was keeping `example-runner-ash` on `ash 0.35`, leading to two builds of `ash` (it's not the only cause of build duplication, but it was getting in the way).

With this PR, I can unify those dependencies quite nicely (though, again, can't actually test native functionality on macOS).

---

Also, whoever lands this PR should publish the new version (I don't think I have the power to, but also I'd rather not touch that part).