### PR TITLE
Upgrade MoltenVK to 1.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ash-molten"
 description = "Statically linked MoltenVK for Vulkan on Mac using Ash"
-version = "0.14.0+1.1.10"
+version = "0.15.0+1.2.2"
 authors = [
     "Embark <opensource@embark-studios.com>",
     "Maik Klein <maik.klein@embark-studios.com>",

--- a/build/build.rs
+++ b/build/build.rs
@@ -4,7 +4,7 @@ mod mac {
     use std::path::{Path, PathBuf};
 
     // MoltenVK git tagged release to use
-    pub static MOLTEN_VK_VERSION: &str = "1.1.10";
+    pub static MOLTEN_VK_VERSION: &str = "1.2.2";
     pub static MOLTEN_VK_PATCH: Option<&str> = None;
 
     // The next two are useful for different kinds of bisection to find bugs.


### PR DESCRIPTION
I followed the steps, but of course cannot create a release here, so [I created one](https://github.com/attackgoat/ash-molten-fork/releases/tag/v0.15.0%2B1.2.2) on my fork. The zipped framework files exclude tvOS and the simulator `.a` files and are not listed in the `.plist` in the same manner as the current version.

<details>
<summary>Mac M2 test results</summary>

```
[mvk-info] MoltenVK version 1.2.2, supporting Vulkan version 1.2.239.
The following 84 Vulkan extensions are supported:
        VK_KHR_16bit_storage v1
        VK_KHR_8bit_storage v1
        VK_KHR_bind_memory2 v1
        VK_KHR_buffer_device_address v1
        VK_KHR_copy_commands2 v1
        VK_KHR_create_renderpass2 v1
        VK_KHR_dedicated_allocation v3
        VK_KHR_depth_stencil_resolve v1
        VK_KHR_descriptor_update_template v1
        VK_KHR_device_group v4
        VK_KHR_device_group_creation v1
        VK_KHR_driver_properties v1
        VK_KHR_dynamic_rendering v1
        VK_KHR_external_fence v1
        VK_KHR_external_fence_capabilities v1
        VK_KHR_external_memory v1
        VK_KHR_external_memory_capabilities v1
        VK_KHR_external_semaphore v1
        VK_KHR_external_semaphore_capabilities v1
        VK_KHR_fragment_shader_barycentric v1
        VK_KHR_get_memory_requirements2 v1
        VK_KHR_get_physical_device_properties2 v2
        VK_KHR_get_surface_capabilities2 v1
        VK_KHR_imageless_framebuffer v1
        VK_KHR_image_format_list v1
        VK_KHR_maintenance1 v2
        VK_KHR_maintenance2 v1
        VK_KHR_maintenance3 v1
        VK_KHR_multiview v1
        VK_KHR_portability_subset v1
        VK_KHR_push_descriptor v2
        VK_KHR_relaxed_block_layout v1
        VK_KHR_sampler_mirror_clamp_to_edge v3
        VK_KHR_sampler_ycbcr_conversion v14
        VK_KHR_separate_depth_stencil_layouts v1
        VK_KHR_shader_draw_parameters v1
        VK_KHR_shader_float_controls v4
        VK_KHR_shader_float16_int8 v1
        VK_KHR_shader_subgroup_extended_types v1
        VK_KHR_spirv_1_4 v1
        VK_KHR_storage_buffer_storage_class v1
        VK_KHR_surface v25
        VK_KHR_swapchain v70
        VK_KHR_swapchain_mutable_format v1
        VK_KHR_timeline_semaphore v2
        VK_KHR_uniform_buffer_standard_layout v1
        VK_KHR_variable_pointers v1
        VK_EXT_buffer_device_address v2
        VK_EXT_debug_marker v4
        VK_EXT_debug_report v10
        VK_EXT_debug_utils v2
        VK_EXT_descriptor_indexing v2
        VK_EXT_fragment_shader_interlock v1
        VK_EXT_hdr_metadata v2
        VK_EXT_host_query_reset v1
        VK_EXT_image_robustness v1
        VK_EXT_inline_uniform_block v1
        VK_EXT_memory_budget v1
        VK_EXT_metal_objects v1
        VK_EXT_metal_surface v1
        VK_EXT_post_depth_coverage v1
        VK_EXT_private_data v1
        VK_EXT_robustness2 v1
        VK_EXT_sample_locations v1
        VK_EXT_scalar_block_layout v1
        VK_EXT_separate_stencil_usage v1
        VK_EXT_shader_stencil_export v1
        VK_EXT_shader_viewport_index_layer v1
        VK_EXT_subgroup_size_control v2
        VK_EXT_swapchain_colorspace v4
        VK_EXT_texel_buffer_alignment v1
        VK_EXT_texture_compression_astc_hdr v1
        VK_EXT_vertex_attribute_divisor v3
        VK_AMD_gpu_shader_half_float v2
        VK_AMD_negative_viewport_height v1
        VK_AMD_shader_image_load_store_lod v1
        VK_AMD_shader_trinary_minmax v1
        VK_IMG_format_pvrtc v1
        VK_INTEL_shader_integer_functions2 v1
        VK_GOOGLE_display_timing v1
        VK_MVK_macos_surface v3
        VK_MVK_moltenvk v36
        VK_NV_fragment_shader_barycentric v1
        VK_NV_glsl_shader v1
[mvk-info] GPU device:
        model: Apple M2
        type: Integrated
        vendorID: 0x106b
        deviceID: 0xd0003ef
        pipelineCacheUUID: FB581E45-0D00-03EF-0000-000000000000
supports the following Metal Versions, GPU's and Feature Sets:
        Metal Shading Language 3.0
        GPU Family Apple 7
        GPU Family Apple 6
        GPU Family Apple 5
        GPU Family Apple 4
        GPU Family Apple 3
        GPU Family Apple 2
        GPU Family Apple 1
        GPU Family Mac 2
        GPU Family Mac 1
        GPU Family Common 3
        GPU Family Common 2
        GPU Family Common 1
        macOS GPU Family 2 v1
        macOS GPU Family 1 v4
        macOS GPU Family 1 v3
        macOS GPU Family 1 v2
        macOS GPU Family 1 v1
[mvk-info] Created VkInstance for Vulkan version 1.2.0, as requested by app, with the following 2 Vulkan extensions enabled:
        VK_KHR_surface v25
        VK_EXT_metal_surface v1
```
</details>

See [attackgoat/#59](https://github.com/attackgoat/screen-13/issues/59)