### PR TITLE
Upgrade MoltenVK to 1.2.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ash-molten"
 description = "Statically linked MoltenVK for Vulkan on Mac using Ash"
-version = "0.15.0+1.2.2"
+version = "0.16.0+1.2.6"
 authors = [
     "Embark <opensource@embark-studios.com>",
     "Maik Klein <maik.klein@embark-studios.com>",

--- a/build/build.rs
+++ b/build/build.rs
@@ -4,7 +4,7 @@ mod mac {
     use std::path::{Path, PathBuf};
 
     // MoltenVK git tagged release to use
-    pub static MOLTEN_VK_VERSION: &str = "1.2.2";
+    pub static MOLTEN_VK_VERSION: &str = "1.2.6";
     pub static MOLTEN_VK_PATCH: Option<&str> = None;
 
     // The next two are useful for different kinds of bisection to find bugs.
@@ -195,8 +195,6 @@ mod mac {
         let unzip_status = Command::new("unzip")
             .arg("-o")
             .arg(&download_path)
-            .arg("-x")
-            .arg("__MACOSX/*")
             .arg("-d")
             .arg(target_dir.as_ref())
             .status()


### PR DESCRIPTION
Have done some basic smoke testing on ark locally.

Difference between `1.2.2` and `1.2.6` in `cargo run` output on a Mac M1:

```diff
--- old.txt	2023-10-25 09:44:05
+++ new.txt	2023-10-25 09:44:10
@@ -1,5 +1,5 @@
-[mvk-info] MoltenVK version 1.2.2, supporting Vulkan version 1.2.239.
-	The following 84 Vulkan extensions are supported:
+[mvk-info] MoltenVK version 1.2.6, supporting Vulkan version 1.2.268.
+	The following 102 Vulkan extensions are supported:
 		VK_KHR_16bit_storage v1
 		VK_KHR_8bit_storage v1
 		VK_KHR_bind_memory2 v1
@@ -7,6 +7,7 @@
 		VK_KHR_copy_commands2 v1
 		VK_KHR_create_renderpass2 v1
 		VK_KHR_dedicated_allocation v3
+		VK_KHR_deferred_host_operations v4
 		VK_KHR_depth_stencil_resolve v1
 		VK_KHR_descriptor_update_template v1
 		VK_KHR_device_group v4
@@ -25,9 +26,11 @@
 		VK_KHR_get_surface_capabilities2 v1
 		VK_KHR_imageless_framebuffer v1
 		VK_KHR_image_format_list v1
+		VK_KHR_incremental_present v2
 		VK_KHR_maintenance1 v2
 		VK_KHR_maintenance2 v1
 		VK_KHR_maintenance3 v1
+		VK_KHR_map_memory2 v1
 		VK_KHR_multiview v1
 		VK_KHR_portability_subset v1
 		VK_KHR_push_descriptor v2
@@ -38,20 +41,27 @@
 		VK_KHR_shader_draw_parameters v1
 		VK_KHR_shader_float_controls v4
 		VK_KHR_shader_float16_int8 v1
+		VK_KHR_shader_non_semantic_info v1
 		VK_KHR_shader_subgroup_extended_types v1
 		VK_KHR_spirv_1_4 v1
 		VK_KHR_storage_buffer_storage_class v1
 		VK_KHR_surface v25
 		VK_KHR_swapchain v70
 		VK_KHR_swapchain_mutable_format v1
+		VK_KHR_synchronization2 v1
 		VK_KHR_timeline_semaphore v2
 		VK_KHR_uniform_buffer_standard_layout v1
 		VK_KHR_variable_pointers v1
+		VK_EXT_4444_formats v1
 		VK_EXT_buffer_device_address v2
+		VK_EXT_calibrated_timestamps v2
 		VK_EXT_debug_marker v4
 		VK_EXT_debug_report v10
 		VK_EXT_debug_utils v2
 		VK_EXT_descriptor_indexing v2
+		VK_EXT_extended_dynamic_state v1
+		VK_EXT_extended_dynamic_state2 v1
+		VK_EXT_external_memory_host v1
 		VK_EXT_fragment_shader_interlock v1
 		VK_EXT_hdr_metadata v2
 		VK_EXT_host_query_reset v1
@@ -60,16 +70,24 @@
 		VK_EXT_memory_budget v1
 		VK_EXT_metal_objects v1
 		VK_EXT_metal_surface v1
+		VK_EXT_pipeline_creation_cache_control v3
+		VK_EXT_pipeline_creation_feedback v1
 		VK_EXT_post_depth_coverage v1
 		VK_EXT_private_data v1
 		VK_EXT_robustness2 v1
 		VK_EXT_sample_locations v1
 		VK_EXT_scalar_block_layout v1
 		VK_EXT_separate_stencil_usage v1
+		VK_EXT_shader_atomic_float v1
+		VK_EXT_shader_demote_to_helper_invocation v1
 		VK_EXT_shader_stencil_export v1
+		VK_EXT_shader_subgroup_ballot v1
+		VK_EXT_shader_subgroup_vote v1
 		VK_EXT_shader_viewport_index_layer v1
 		VK_EXT_subgroup_size_control v2
+		VK_EXT_surface_maintenance1 v1
 		VK_EXT_swapchain_colorspace v4
+		VK_EXT_swapchain_maintenance1 v1
 		VK_EXT_texel_buffer_alignment v1
 		VK_EXT_texture_compression_astc_hdr v1
 		VK_EXT_vertex_attribute_divisor v3
@@ -81,7 +99,7 @@
 		VK_INTEL_shader_integer_functions2 v1
 		VK_GOOGLE_display_timing v1
 		VK_MVK_macos_surface v3
-		VK_MVK_moltenvk v36
+		VK_MVK_moltenvk v37
 		VK_NV_fragment_shader_barycentric v1
 		VK_NV_glsl_shader v1
 [mvk-info] GPU device:
@@ -89,9 +107,11 @@
 		type: Integrated
 		vendorID: 0x106b
 		deviceID: 0xe0003ef
-		pipelineCacheUUID: FB581E45-0E00-03EF-0000-000000000000
+		pipelineCacheUUID: 9E4EE9E6-0E00-03EF-0000-000000000000
+		GPU memory available: 49152 MB
+		GPU memory used: 0 MB
 	supports the following Metal Versions, GPU's and Feature Sets:
-		Metal Shading Language 3.0
+		Metal Shading Language 3.1
 		GPU Family Apple 7
 		GPU Family Apple 6
 		GPU Family Apple 5
```