### PR TITLE
Upgrade MoltenVK to 1.2.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ash-molten"
 description = "Statically linked MoltenVK for Vulkan on Mac using Ash"
-version = "0.16.0+1.2.6"
+version = "0.17.0+1.2.7"
 authors = [
     "Embark <opensource@embark-studios.com>",
     "Maik Klein <maik.klein@embark-studios.com>",

--- a/build/build.rs
+++ b/build/build.rs
@@ -4,7 +4,7 @@ mod mac {
     use std::path::{Path, PathBuf};
 
     // MoltenVK git tagged release to use
-    pub static MOLTEN_VK_VERSION: &str = "1.2.6";
+    pub static MOLTEN_VK_VERSION: &str = "1.2.7";
     pub static MOLTEN_VK_PATCH: Option<&str> = None;
 
     // The next two are useful for different kinds of bisection to find bugs.


### PR DESCRIPTION
Changelog: https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.7

Have done some basic smoke testing on wim locally.

Difference between `1.2.6` and `1.2.7` in cargo run output on a Mac M1 (note that `MVK_CONFIG_LOG_LEVEL=3` needs to be set now for the log message to be output):

```diff
-[mvk-info] MoltenVK version 1.2.6, supporting Vulkan version 1.2.268.
-	The following 102 Vulkan extensions are supported:
+[mvk-info] MoltenVK version 1.2.7, supporting Vulkan version 1.2.275.
+	The following 108 Vulkan extensions are supported:
 		VK_KHR_16bit_storage v1
 		VK_KHR_8bit_storage v1
 		VK_KHR_bind_memory2 v1
 		VK_KHR_buffer_device_address v1
+		VK_KHR_calibrated_timestamps v1
 		VK_KHR_copy_commands2 v1
 		VK_KHR_create_renderpass2 v1
 		VK_KHR_dedicated_allocation v3
@@ -24,6 +25,7 @@
 		VK_KHR_external_semaphore v1
 		VK_KHR_external_semaphore_capabilities v1
 		VK_KHR_fragment_shader_barycentric v1
+		VK_KHR_format_feature_flags2 v2
 		VK_KHR_get_memory_requirements2 v1
 		VK_KHR_get_physical_device_properties2 v2
 		VK_KHR_get_surface_capabilities2 v1
@@ -55,6 +57,7 @@
 		VK_KHR_timeline_semaphore v2
 		VK_KHR_uniform_buffer_standard_layout v1
 		VK_KHR_variable_pointers v1
+		VK_KHR_vertex_attribute_divisor v1
 		VK_EXT_4444_formats v1
 		VK_EXT_buffer_device_address v2
 		VK_EXT_calibrated_timestamps v2
@@ -64,12 +67,15 @@
 		VK_EXT_descriptor_indexing v2
 		VK_EXT_extended_dynamic_state v1
 		VK_EXT_extended_dynamic_state2 v1
+		VK_EXT_extended_dynamic_state3 v2
 		VK_EXT_external_memory_host v1
 		VK_EXT_fragment_shader_interlock v1
 		VK_EXT_hdr_metadata v2
+		VK_EXT_headless_surface v1
 		VK_EXT_host_query_reset v1
 		VK_EXT_image_robustness v1
 		VK_EXT_inline_uniform_block v1
+		VK_EXT_layer_settings v2
 		VK_EXT_memory_budget v1
 		VK_EXT_metal_objects v1
 		VK_EXT_metal_surface v1
@@ -110,11 +116,11 @@
 		type: Integrated
 		vendorID: 0x106b
 		deviceID: 0xe0203ef
-		pipelineCacheUUID: 9E4EE9E6-0E02-03EF-0000-000000000000
+		pipelineCacheUUID: 66F6FF1E-0E02-03EF-0000-000000000000
 		GPU memory available: 49152 MB
 		GPU memory used: 0 MB
 	supports the following Metal Versions, GPU's and Feature Sets:
-		Metal Shading Language 3.0
+		Metal Shading Language 3.1
 		GPU Family Apple 7
 		GPU Family Apple 6
 		GPU Family Apple 5
```