### PR TITLE
Upgrade MoltenVK to 1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+## [0.18.0] - 2024-03-19
+### Changed
+- [PR#82](https://github.com/EmbarkStudios/ash-molten/pull/82) Upgrade MoltenVK to `1.2.8`
+
+## [0.17.0] - 2024-01-24
+### Changed
+- [PR#81](https://github.com/EmbarkStudios/ash-molten/pull/81) Upgrade MoltenVK to `1.2.7`
+
+## [0.16.0] - 2023-11-03
 ### Changed
 - [PR#76](https://github.com/EmbarkStudios/ash-molten/pull/76) Upgrade MoltenVK to `1.2.6`
 
@@ -53,7 +63,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update to MoltenVK 1.1.0
 
 <!-- next-url -->
-[Unreleased]: https://github.com/EmbarkStudios/ash-molten/compare/0.15.0...HEAD
+[Unreleased]: https://github.com/EmbarkStudios/ash-molten/compare/0.18.0...HEAD
+[0.18.0]: https://github.com/EmbarkStudios/ash-molten/compare/0.17.0...0.18.0
+[0.17.0]: https://github.com/EmbarkStudios/ash-molten/compare/0.16.0...0.17.0
+[0.16.0]: https://github.com/EmbarkStudios/ash-molten/compare/0.15.0...0.16.0
 [0.15.0]: https://github.com/EmbarkStudios/ash-molten/compare/0.14.0...0.15.0
 [0.14.0]: https://github.com/EmbarkStudios/ash-molten/compare/v0.13.1+1.1.10...0.14.0
 [0.13.1]: https://github.com/EmbarkStudios/ash-molten/compare/v0.13.0+1.1.10...v0.13.1+1.1.10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ash-molten"
 description = "Statically linked MoltenVK for Vulkan on Mac using Ash"
-version = "0.17.0+1.2.7"
+version = "0.18.0+1.2.8"
 authors = [
     "Embark <opensource@embark-studios.com>",
     "Maik Klein <maik.klein@embark-studios.com>",

--- a/build/build.rs
+++ b/build/build.rs
@@ -4,7 +4,7 @@ mod mac {
     use std::path::{Path, PathBuf};
 
     // MoltenVK git tagged release to use
-    pub static MOLTEN_VK_VERSION: &str = "1.2.7";
+    pub static MOLTEN_VK_VERSION: &str = "1.2.8";
     pub static MOLTEN_VK_PATCH: Option<&str> = None;
 
     // The next two are useful for different kinds of bisection to find bugs.

--- a/build/build.rs
+++ b/build/build.rs
@@ -275,7 +275,7 @@ fn main() {
             } else {
                 pb.push(target_dir);
             }
-            pb.push("Package/Latest/MoltenVK/MoltenVK.xcframework");
+            pb.push("Package/Latest/MoltenVK/static/MoltenVK.xcframework");
 
             pb
         };

--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,12 @@ multiple-versions = "deny"
 deny = []
 skip = []
 
+[advisories]
+ignore = [
+    # Unmtaintained `safemem` dependency - only used by plist to build
+    "RUSTSEC-2023-0081",
+]
+
 [licenses]
 unlicensed = "deny"
 # We want really high confidence when inferring licenses from text


### PR DESCRIPTION
Changelog: https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.8

Have done some basic smoke testing on wim locally.

Difference between 1.2.7 and 1.2.8 in `MVK_CONFIG_LOG_LEVEL=3 cargo run --features pre-built` output on a Mac M1:

```diff
-[mvk-info] MoltenVK version 1.2.7, supporting Vulkan version 1.2.275.
-	The following 108 Vulkan extensions are supported:
+[mvk-info] MoltenVK version 1.2.8, supporting Vulkan version 1.2.280.
+	The following 109 Vulkan extensions are supported:
 		VK_KHR_16bit_storage v1
 		VK_KHR_8bit_storage v1
 		VK_KHR_bind_memory2 v1
@@ -43,6 +43,7 @@
 		VK_KHR_shader_draw_parameters v1
 		VK_KHR_shader_float_controls v4
 		VK_KHR_shader_float16_int8 v1
+		VK_KHR_shader_integer_dot_product v1
 		VK_KHR_shader_non_semantic_info v1
 		VK_KHR_shader_subgroup_extended_types v1
 		VK_KHR_spirv_1_4 v1
@@ -113,7 +114,7 @@
 		type: Integrated
 		vendorID: 0x106b
 		deviceID: 0xe0303ef
-		pipelineCacheUUID: 66F6FF1E-0E03-03EF-0000-000000000000
+		pipelineCacheUUID: 1D98BABB-0E03-03EF-0000-000000000000
 		GPU memory available: 49152 MB
 		GPU memory used: 0 MB
 	supports the following Metal Versions, GPU's and Feature Sets:
```