### PR TITLE
Upgrade to `ash 0.38`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ build = "build/build.rs"
 #
 # NB: you must check that `ash-molten` compiles with every `ash` version
 # in this range, not just the start and the end, to be sure it's compatible.
-version = ">=0.35, <=0.37"
+version = "0.38"
 default-features = false
 
 [build-dependencies]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -77,16 +77,16 @@ fn main() {
         let entry = ash_molten::load();
         let app_name = CString::new("Hello Static Molten").unwrap();
 
-        let appinfo = vk::ApplicationInfo::builder()
+        let appinfo = vk::ApplicationInfo::default()
             .application_name(&app_name)
             .application_version(0)
             .engine_name(&app_name)
             .engine_version(0)
             .api_version(vk::make_api_version(0, 1, 0, 0));
 
-        let create_info = vk::InstanceCreateInfo::builder().application_info(&appinfo);
+        let create_info = vk::InstanceCreateInfo::default().application_info(&appinfo);
         let instance = entry.create_instance(&create_info, None).expect("Instance");
         let devices = instance.enumerate_physical_devices();
-        println!("{:?}", devices);
+        println!("Physical devices: {:?}", devices);
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -71,16 +71,15 @@
 #![allow(unsafe_code)]
 
 use ash::vk;
-use std::ffi::CString;
 fn main() {
     unsafe {
         let entry = ash_molten::load();
-        let app_name = CString::new("Hello Static Molten").unwrap();
+        let app_name = c"Hello Static Molten";
 
         let appinfo = vk::ApplicationInfo::default()
-            .application_name(&app_name)
+            .application_name(app_name)
             .application_version(0)
-            .engine_name(&app_name)
+            .engine_name(app_name)
             .engine_version(0)
             .api_version(vk::make_api_version(0, 1, 0, 0));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use ash::{vk, Entry};
+use ash::vk;
 
 extern "system" {
     fn vkGetInstanceProcAddr(
@@ -8,12 +8,12 @@ extern "system" {
 }
 
 /// Fetches the function pointer to `vkGetInstanceProcAddr` which is statically linked.
-pub fn load() -> Entry {
-    let static_fn = vk::StaticFn {
+pub fn load() -> ash::Entry {
+    let static_fn = ash::StaticFn {
         get_instance_proc_addr: vkGetInstanceProcAddr,
     };
     #[allow(unsafe_code)]
     unsafe {
-        Entry::from_static_fn(static_fn)
+        ash::Entry::from_static_fn(static_fn)
     }
 }


### PR DESCRIPTION
Unfortunately the modules moved around (for a purer `ash::vk`) which make this crate release incompatible with former breaking releases.
