### PR TITLE
Use `ash`' built-in `"linked"` feature for static linking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ build = "build/build.rs"
 # in this range, not just the start and the end, to be sure it's compatible.
 version = ">=0.35, <=0.37"
 default-features = false
+features = ["linked"]
 
 [build-dependencies]
 anyhow = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,5 @@
-use ash::{vk, Entry};
+use ash::Entry;
 
-extern "system" {
-    fn vkGetInstanceProcAddr(
-        instance: vk::Instance,
-        p_name: *const std::os::raw::c_char,
-    ) -> vk::PFN_vkVoidFunction;
-}
-
-/// Fetches the function pointer to `vkGetInstanceProcAddr` which is statically linked.
 pub fn load() -> Entry {
-    let static_fn = vk::StaticFn {
-        get_instance_proc_addr: vkGetInstanceProcAddr,
-    };
-    #[allow(unsafe_code)]
-    unsafe {
-        Entry::from_static_fn(static_fn)
-    }
+    Entry::linked()
 }


### PR DESCRIPTION
All the code here to define an `extern "system"` symbol for `vkGetInstanceProcAddr` and use it inside `Entry` (via `StaticFn`) was included in Ash release `0.35` (the minimum compatbile with `ash-molten` already) to make it much more trivial to static-link on various platforms, including against `MoltenVK` here.

This change makes the `lib.rs` portion of `MoltenVK` pretty much useless as it's only forwarding the call (and `load()` should perhaps be renamed?), should we rethink the structure of the crate a bit.
