### PR TITLE
Release version `0.19.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+## [0.19.0] - 2024-04-03
+### Changed
+- [PR#83](https://github.com/EmbarkStudios/ash-molten/pull/83) Upgrade `ash` to `0.38`
+
 ## [0.18.0] - 2024-03-19
 ### Changed
 - [PR#82](https://github.com/EmbarkStudios/ash-molten/pull/82) Upgrade MoltenVK to `1.2.8`
@@ -64,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-url -->
 [Unreleased]: https://github.com/EmbarkStudios/ash-molten/compare/0.18.0...HEAD
+[0.19.0]: https://github.com/EmbarkStudios/ash-molten/compare/0.18.0...0.19.0
 [0.18.0]: https://github.com/EmbarkStudios/ash-molten/compare/0.17.0...0.18.0
 [0.17.0]: https://github.com/EmbarkStudios/ash-molten/compare/0.16.0...0.17.0
 [0.16.0]: https://github.com/EmbarkStudios/ash-molten/compare/0.15.0...0.16.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ash-molten"
 description = "Statically linked MoltenVK for Vulkan on Mac using Ash"
-version = "0.18.0+1.2.8"
+version = "0.19.0+1.2.8"
 authors = [
     "Embark <opensource@embark-studios.com>",
     "Maik Klein <maik.klein@embark-studios.com>",

--- a/deny.toml
+++ b/deny.toml
@@ -3,12 +3,6 @@ multiple-versions = "deny"
 deny = []
 skip = []
 
-[advisories]
-ignore = [
-    # Unmtaintained `safemem` dependency - only used by plist to build
-    "RUSTSEC-2023-0081",
-]
-
 [licenses]
 unlicensed = "deny"
 # We want really high confidence when inferring licenses from text


### PR DESCRIPTION
Release `0.19` containing the update to `ash` version `0.38` as the only change: https://github.com/EmbarkStudios/ash-molten/pull/83