### PR TITLE
Fix mistake in changelog

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - uses: Swatinem/rust-cache@v2
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.5.app
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: "clippy, rustfmt"
@@ -30,7 +30,7 @@ jobs:
   cargo-deny:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
 
@@ -40,7 +40,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.5.app
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v4
         with:
@@ -55,7 +55,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.5.app
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update to MoltenVK 1.1.0
 
 <!-- next-url -->
-[Unreleased]: https://github.com/EmbarkStudios/ash-molten/compare/0.18.0...HEAD
+[Unreleased]: https://github.com/EmbarkStudios/ash-molten/compare/0.19.0...HEAD
 [0.19.0]: https://github.com/EmbarkStudios/ash-molten/compare/0.18.0...0.19.0
 [0.18.0]: https://github.com/EmbarkStudios/ash-molten/compare/0.17.0...0.18.0
 [0.17.0]: https://github.com/EmbarkStudios/ash-molten/compare/0.16.0...0.17.0


### PR DESCRIPTION
Fix a mistake pointed out by @MarijnS95.

Also drive-by update `actions/checkout` (from `v3` to `v4`) and `actions/setup-python` (from `v4` to `v5`) to fix warnings about old node.js versions in the github CI.